### PR TITLE
Dismiss keyboard when dragging the search result list

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -283,6 +283,7 @@ class _HomePageState extends State<HomePage> {
         final results = showSearchResultsHelper(
             Theme.of(context).textTheme.bodyLarge!, searchModeState.mode);
         return ListView.separated(
+          keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
           separatorBuilder: (_, __) => const Divider(),
           itemBuilder: (_, index) => results[index],
           itemCount: results.length,


### PR DESCRIPTION
Keyboard may hinder the user to select the last result in the search result list in the case where the list is very long. We may just dismiss the keyboard when the user drag the list, as when the user tap on the search bar the keyboard will show up again automatically.